### PR TITLE
Removed statement about pre-filtering

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -31,20 +31,13 @@
 
        <div id="outputbody" class="collapse">
 <p>We e-mail a set of files to you: a vowel plot showing the mean of all vowels
-  in your data (including both stressed and unstressed vowels)
-and a spreadsheet with both unnormalized and Lobanov-normalized
+  in your data (including both stressed and unstressed vowels), a spreadsheet with both unnormalized and Lobanov-normalized
 formant measurements,
 the same spreadsheet formatted for convenient uploading to <a
 href="http://lvc.uoregon.edu/norm/about_norm1.php">NORM</a>, the
 alignments, and the transcriptions.
-You can select whether you want to filter out stop words
-<a href="/static/content/stopwords.txt">(from this list)</a>
-and high-bandwidth vowels.
 </p>
 
-<p>We recommend remove the unstressed vowels from your spreadsheet
-  output before plotting it in NORM.
-</p>
 
 <p>If you are using the completely automated feature, you also have the option of
 editing the transcriptions online, and seamlessly re-running your task


### PR DESCRIPTION
I changed the statement in the FAQs about the data being pre-filtered. We can add it back in when the filtering options are running on the website.